### PR TITLE
Enable to compile with Haxe4 compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# knockout.hx
+
+knockout.hx is an extern file for Knockout.
+
+## How to use
+
+```javascript
+// Create an observable
+var observable:Observable<String> = Knockout.observable("hello");
+
+// Writing
+observable.set("good by");
+// other way
+observable << "good by";
+
+// Reading
+var value = observable.get();
+// Implicit Casts
+var value:String = observable;
+
+//Activating
+Knockout.applyBindings({prop:observable});
+
+```
+
+See example: text/Test.hx

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 knockout.hx is an extern file for Knockout.
 
+## Install
+
+```
+haxelib install knockout.hx
+```
+
 ## How to use
 
 ```javascript

--- a/haxelib.json
+++ b/haxelib.json
@@ -4,8 +4,8 @@
     "license": "Public",
     "tags": ["js", "extern", "knockout"],
     "description": "Knockout extern",
-    "version": "3.0.0",
-    "releasenote": "Support Knockout 3.0.0",
+    "version": "3.1.0",
+    "releasenote": "Support Knockout 3.1.0",
     "contributors": ["hakurai"],
     "dependencies": {}
 }

--- a/haxelib.json
+++ b/haxelib.json
@@ -4,8 +4,8 @@
     "license": "Public",
     "tags": ["js", "extern", "knockout"],
     "description": "Knockout extern",
-    "version": "2.3.0",
-    "releasenote": "Support Knockout 2.3.0",
+    "version": "3.0.0",
+    "releasenote": "Support Knockout 3.0.0",
     "contributors": ["hakurai"],
     "dependencies": {}
 }

--- a/haxelib.json
+++ b/haxelib.json
@@ -4,8 +4,8 @@
     "license": "Public",
     "tags": ["js", "extern", "knockout"],
     "description": "Knockout extern",
-    "version": "3.1.0",
-    "releasenote": "Support Knockout 3.1.0",
+    "version": "3.2.0",
+    "releasenote": "Support Knockout 3.2.0",
     "contributors": ["hakurai"],
     "dependencies": {}
 }

--- a/haxelib.json
+++ b/haxelib.json
@@ -4,8 +4,8 @@
     "license": "Public",
     "tags": ["js", "extern", "knockout"],
     "description": "Knockout extern",
-    "version": "3.2.0",
-    "releasenote": "Support Knockout 3.2.0",
+    "version": "3.2.1",
+    "releasenote": "Support Knockout 3.2.0/Haxe3.2.0",
     "contributors": ["hakurai"],
     "dependencies": {}
 }

--- a/haxelib.json
+++ b/haxelib.json
@@ -6,5 +6,6 @@
     "description": "Knockout extern",
     "version": "2.3.0",
     "releasenote": "Initial release",
-    "contributors": ["hakurai"]
+    "contributors": ["hakurai"],
+    "dependencies": {}
 }

--- a/haxelib.json
+++ b/haxelib.json
@@ -1,11 +1,11 @@
 {
     "name": "knockout.hx",
-    "url": "https://github.com/hakurai/Knockout.hx",
+    "url": "https://github.com/nulab/Knockout.hx",
     "license": "Public",
     "tags": ["js", "extern", "knockout"],
     "description": "Knockout extern",
     "version": "2.3.0",
-    "releasenote": "Initial release",
+    "releasenote": "Support Knockout 2.3.0",
     "contributors": ["hakurai"],
     "dependencies": {}
 }

--- a/haxelib.xml
+++ b/haxelib.xml
@@ -4,5 +4,5 @@
     <tag v="javascript"/>
     <tag v="extern"/>
     <description>Knockout extern</description>
-    <version name="3.2.0">Support Knockout 3.2.0</version>
+    <version name="3.2.1">Support Knockout 3.2.0/Haxe3.2.0</version>
 </project>

--- a/haxelib.xml
+++ b/haxelib.xml
@@ -4,5 +4,5 @@
     <tag v="javascript"/>
     <tag v="extern"/>
     <description>Knockout extern</description>
-    <version name="2.3.0">Initial release</version>
+    <version name="3.2.0">Support Knockout 3.2.0</version>
 </project>

--- a/knockout/BindingContext.hx
+++ b/knockout/BindingContext.hx
@@ -2,14 +2,14 @@ package knockout;
 
 extern class BindingContext {
 
-    public var parent(get_parent, null):Null<Dynamic>;
-    public var parents(get_parents, null):Null<Array<Dynamic>>;
-    public var root(get_root, null):Dynamic;
-    public var data(get_data, null):Null<Dynamic>;
-    public var index(get_index, null):Null<Int>;
-    public var parentContext(get_parentContext, null):Null<BindingContext>;
-    public var context(get_context, null):BindingContext;
-    public var element(get_element, null):js.html.Node;
+    public var parent(get, null):Null<Dynamic>;
+    public var parents(get, null):Null<Array<Dynamic>>;
+    public var root(get, null):Dynamic;
+    public var data(get, null):Null<Dynamic>;
+    public var index(get, null):Null<Int>;
+    public var parentContext(get, null):Null<BindingContext>;
+    public var context(get, null):BindingContext;
+    public var element(get, null):js.html.Node;
 
     private inline function get_parent():Null<Dynamic> untyped {
         return this["$parent"];

--- a/knockout/BindingContext.hx
+++ b/knockout/BindingContext.hx
@@ -1,7 +1,6 @@
 package knockout;
 
-extern
-class BindingContext {
+extern class BindingContext {
 
     public var parent(get_parent, null):Null<Dynamic>;
     public var parents(get_parents, null):Null<Array<Dynamic>>;

--- a/knockout/ComponentConfig.hx
+++ b/knockout/ComponentConfig.hx
@@ -4,5 +4,5 @@ package knockout;
 typedef ComponentConfig = {
     var viewModel:Dynamic;
     var template:Dynamic;
-    var ?synchronous:Bool;
+    @:optional var synchronous:Bool;
 }

--- a/knockout/ComponentConfig.hx
+++ b/knockout/ComponentConfig.hx
@@ -1,0 +1,7 @@
+package knockout;
+
+
+typedef ComponentConfig = {
+    var viewModel:Dynamic;
+    var template:Dynamic;
+}

--- a/knockout/ComponentConfig.hx
+++ b/knockout/ComponentConfig.hx
@@ -4,5 +4,5 @@ package knockout;
 typedef ComponentConfig = {
     var viewModel:Dynamic;
     var template:Dynamic;
-    var synchronous:Bool;
+    var ?synchronous:Bool;
 }

--- a/knockout/ComponentConfig.hx
+++ b/knockout/ComponentConfig.hx
@@ -4,4 +4,5 @@ package knockout;
 typedef ComponentConfig = {
     var viewModel:Dynamic;
     var template:Dynamic;
+    var synchronous:Bool;
 }

--- a/knockout/ComponentLoader.hx
+++ b/knockout/ComponentLoader.hx
@@ -1,0 +1,13 @@
+package knockout;
+
+interface ComponentLoader {
+
+    public function getConfig(name:String, callback:ComponentConfig -> Void):Void;
+
+    public function loadComponent(name:String, componentConfig:ComponentConfig, callback:Dynamic -> Void):Void;
+
+    public function loadTemplate(name:String, templateConfig:Dynamic, callback:Array<js.html.Node> -> Void):Void;
+
+    public function loadViewModel(name:String, viewModelConfig:Dynamic, callback:Dynamic -> Void):Void;
+
+}

--- a/knockout/Components.hx
+++ b/knockout/Components.hx
@@ -1,8 +1,7 @@
 package knockout;
 
 @:native("ko.components")
-extern
-class Components {
+extern class Components {
 
     public function get(componentName:String, callback:ComponentConfig -> Void):Void;
 

--- a/knockout/Components.hx
+++ b/knockout/Components.hx
@@ -1,0 +1,21 @@
+package knockout;
+
+@:native("ko.components")
+extern
+class Components {
+
+    public function get(componentName:String, callback:ComponentConfig -> Void):Void;
+
+    public function clearCachedDefinition(componentName:String):Void;
+    
+    public function register(componentName:String, config:ComponentConfig):Void;
+    
+    public function isRegistered(componentName:String):Void;
+    
+    public function unregister(componentName:String):Void;
+    
+    public var defaultLoader:ComponentLoader;
+    
+    public var loaders:Array<ComponentLoader>;
+
+}

--- a/knockout/ComputedContext.hx
+++ b/knockout/ComputedContext.hx
@@ -1,0 +1,11 @@
+package knockout;
+
+@:native("ko.computedContext")
+extern
+class ComputedContext {
+
+    public function getDependenciesCount():Int;
+
+    public function isInitial():Bool;
+
+}

--- a/knockout/ComputedContext.hx
+++ b/knockout/ComputedContext.hx
@@ -1,8 +1,7 @@
 package knockout;
 
 @:native("ko.computedContext")
-extern
-class ComputedContext {
+extern class ComputedContext {
 
     public function getDependenciesCount():Int;
 

--- a/knockout/DependentObservable.hx
+++ b/knockout/DependentObservable.hx
@@ -3,47 +3,47 @@ import knockout.Subscribable;
 
 abstract DependentObservable<T>(DependentObservableExtern<T>) from DependentObservableExtern<T>{
 
-    public static var fn:Dynamic = DependentObservableFn;
+    inline public static var fn:Dynamic = DependentObservableFn;
 
-    inline function new(observable:DependentObservableExtern<T>) {
+    @:extern inline function new(observable:DependentObservableExtern<T>) {
         this = observable;
     }
 
-    @:to inline public function toValue():T {
+    @:extern @:to inline public function toValue():T {
         return this.getter()();
     }
 
-    inline public function set(newValue:T):Void {
+    @:extern inline public function set(newValue:T):Void {
         return this.setter()(newValue);
     }
 
-    inline public function get():Null<T> {
+    @:extern inline public function get():Null<T> {
         return this.getter()();
     }
 
-    inline public function peek():T {
+    @:extern inline public function peek():T {
         return this.peek();
     }
 
-    inline public function isActive():Bool {
+    @:extern inline public function isActive():Bool {
         return this.isActive();
     }
 
 // Subscribable methods
 
-    inline public function extend(source:Dynamic):Subscribable<T> {
+    @:extern inline public function extend(source:Dynamic):Subscribable<T> {
         return this.extend(source);
     }
 
-    inline public function dispose():Void {
+    @:extern inline public function dispose():Void {
         this.dispose();
     }
 
-    inline public function getSubscriptionsCount():Int {
+    @:extern inline public function getSubscriptionsCount():Int {
         return this.getSubscriptionsCount();
     }
 
-    inline public function subscribe(call:T -> Void, ?callbackTarget:Dynamic, ?event:String):Subscription {
+    @:extern inline public function subscribe(call:T -> Void, ?callbackTarget:Dynamic, ?event:String):Subscription {
         return this.subscribe(call, callbackTarget, event);
     }
 }

--- a/knockout/DependentObservable.hx
+++ b/knockout/DependentObservable.hx
@@ -49,8 +49,7 @@ abstract DependentObservable<T>(DependentObservableExtern<T>) from DependentObse
 }
 
 
-extern
-class DependentObservableExtern<T> extends Subscribable<T>{
+extern class DependentObservableExtern<T> extends Subscribable<T>{
 
 public static var fn:Dynamic;
 public var value(get, set):T;
@@ -70,8 +69,7 @@ public function isActive():Bool;
 }
 
 @:native("ko.dependentObservable.fn")
-extern
-class DependentObservableFn {
+extern class DependentObservableFn {
 
 }
 

--- a/knockout/DomData.hx
+++ b/knockout/DomData.hx
@@ -2,8 +2,7 @@ package knockout;
 
 import js.html.Node;
 @:native("ko.utils.domData")
-extern
-class DomData {
+extern class DomData {
 
     public function clear(node:Node):Bool;
     

--- a/knockout/DomData.hx
+++ b/knockout/DomData.hx
@@ -1,0 +1,10 @@
+package knockout;
+
+import js.html.Node;
+@:native("ko.utils.domData")
+extern
+class DomData {
+
+    public function clear(node:Node):Bool;
+    
+}

--- a/knockout/ExpressionRewriting.hx
+++ b/knockout/ExpressionRewriting.hx
@@ -2,8 +2,7 @@ package knockout;
 
 import knockout.Utils.Either;
 @:native("ko.expressionRewriting")
-extern
-class ExpressionRewriting {
+extern class ExpressionRewriting {
 
     public var bindingRewriteValidators:Dynamic;
     

--- a/knockout/ExpressionRewriting.hx
+++ b/knockout/ExpressionRewriting.hx
@@ -1,0 +1,16 @@
+package knockout;
+
+import knockout.Utils.Either;
+@:native("ko.expressionRewriting")
+extern
+class ExpressionRewriting {
+
+    public var bindingRewriteValidators:Dynamic;
+    
+    public var _twoWayBindings:Dynamic;
+
+    public function parseObjectLiteral(objectLiteralString:String):Array<Dynamic>;
+
+    public function preProcessBindings(bindingsStringOrKeyValueArray:Either<String,Array<Dynamic>>, bindingOptions:Dynamic):String;
+
+}

--- a/knockout/ExpressionRewriting.hx
+++ b/knockout/ExpressionRewriting.hx
@@ -1,6 +1,6 @@
 package knockout;
 
-import knockout.Utils.Either;
+import haxe.extern.EitherType;
 @:native("ko.expressionRewriting")
 extern class ExpressionRewriting {
 
@@ -10,6 +10,6 @@ extern class ExpressionRewriting {
 
     public function parseObjectLiteral(objectLiteralString:String):Array<Dynamic>;
 
-    public function preProcessBindings(bindingsStringOrKeyValueArray:Either<String,Array<Dynamic>>, bindingOptions:Dynamic):String;
+    public function preProcessBindings(bindingsStringOrKeyValueArray:EitherType<String,Array<Dynamic>>, bindingOptions:Dynamic):String;
 
 }

--- a/knockout/JsonExpressionRewriting.hx
+++ b/knockout/JsonExpressionRewriting.hx
@@ -1,10 +1,10 @@
 package knockout;
 
-import knockout.Utils.Either;
+import haxe.extern.EitherType;
 @:native("ko.jsonExpressionRewriting")
 extern class JsonExpressionRewriting {
 
-    public function insertPropertyAccessorsIntoJson(bindingsStringOrKeyValueArray:Either<String,Array<Dynamic>>, bindingOptions:Dynamic):String;
+    public function insertPropertyAccessorsIntoJson(bindingsStringOrKeyValueArray:EitherType<String,Array<Dynamic>>, bindingOptions:Dynamic):String;
 
 
 }

--- a/knockout/JsonExpressionRewriting.hx
+++ b/knockout/JsonExpressionRewriting.hx
@@ -2,8 +2,7 @@ package knockout;
 
 import knockout.Utils.Either;
 @:native("ko.jsonExpressionRewriting")
-extern
-class JsonExpressionRewriting {
+extern class JsonExpressionRewriting {
 
     public function insertPropertyAccessorsIntoJson(bindingsStringOrKeyValueArray:Either<String,Array<Dynamic>>, bindingOptions:Dynamic):String;
 

--- a/knockout/JsonExpressionRewriting.hx
+++ b/knockout/JsonExpressionRewriting.hx
@@ -1,0 +1,11 @@
+package knockout;
+
+import knockout.Utils.Either;
+@:native("ko.jsonExpressionRewriting")
+extern
+class JsonExpressionRewriting {
+
+    public function insertPropertyAccessorsIntoJson(bindingsStringOrKeyValueArray:Either<String,Array<Dynamic>>, bindingOptions:Dynamic):String;
+
+
+}

--- a/knockout/Knockout.hx
+++ b/knockout/Knockout.hx
@@ -26,7 +26,7 @@ class Knockout {
 
     public static function observableArray<T>(?value:Either<Array<T>, T>):ObservableArrayExtern<T>;
 
-    public static function computed<T>(evaluatorFunctionOrOptions:Either<Void -> T, DependentObservableOption<T>>):DependentObservableExtern<T>;
+    public static function computed<T>(evaluatorFunctionOrOptions:Either<Void -> T, DependentObservableOption<T>>, ?evaluatorFunctionTarget:Dynamic, ?options:Dynamic):DependentObservableExtern<T>;
 
     public static function applyBindings(viewModel:Dynamic,?rootNode:js.html.Node):Void;
 

--- a/knockout/Knockout.hx
+++ b/knockout/Knockout.hx
@@ -33,6 +33,8 @@ class Knockout {
     public static var nativeTemplateEngine:TemplateEngine;
     
     public static var jqueryTmplTemplateEngine:TemplateEngine;
+    
+    public static var components:Components;
 
     public static function applyBindings(viewModelOrBindingContext:Dynamic,?rootNode:js.html.Node):Void;
     
@@ -51,6 +53,8 @@ class Knockout {
     public static function observableArray<T>(?value:Either<Array<T>, T>):ObservableArrayExtern<T>;
 
     public static function computed<T>(evaluatorFunctionOrOptions:Either<Void -> T, DependentObservableOption<T>>, ?evaluatorFunctionTarget:Dynamic, ?options:Dynamic):DependentObservableExtern<T>;
+    
+    public static function pureComputed<T>(evaluatorFunctionOrOptions:Either<Void -> T, DependentObservableOption<T>>, ?evaluatorFunctionTarget:Dynamic):DependentObservableExtern<T>;
 
     public static function unwrap<T>(value:Either<T, Subscribable<T>>):T;
     

--- a/knockout/Knockout.hx
+++ b/knockout/Knockout.hx
@@ -15,7 +15,9 @@ class Knockout {
     public static var version:String;
     
     public static var extenders:Dynamic;
-    
+
+    public static var computedContext:ComputedContext;
+
     public static var selectExtensions:SelectExtensions;
     
     public static var expressionRewriting:ExpressionRewriting;

--- a/knockout/Knockout.hx
+++ b/knockout/Knockout.hx
@@ -9,8 +9,7 @@ import knockout.TemplateEngine;
 
 
 @:native("ko")
-extern
-class Knockout {
+extern class Knockout {
 
     public static var version:String;
     

--- a/knockout/Knockout.hx
+++ b/knockout/Knockout.hx
@@ -1,7 +1,6 @@
 package knockout;
 
 import knockout.Utils.Either;
-import knockout.Utils.Either;
 import knockout.DependentObservable;
 import knockout.Observable;
 import knockout.ObservableArray;

--- a/knockout/Knockout.hx
+++ b/knockout/Knockout.hx
@@ -15,22 +15,44 @@ class Knockout {
     public static var version:String;
     
     public static var extenders:Dynamic;
+    
+    public static var selectExtensions:SelectExtensions;
+    
+    public static var expressionRewriting:ExpressionRewriting;
+    
+    public static var jsonExpressionRewriting:JsonExpressionRewriting;
+
+    public static var virtualElements:VirtualElements;
+    
+    public static var bindingProvider:Dynamic;
 
     public static var bindingHandlers:BindingHandlerMap;
-    
+
     public static var nativeTemplateEngine:TemplateEngine;
     
     public static var jqueryTmplTemplateEngine:TemplateEngine;
 
+    public static function applyBindings(viewModelOrBindingContext:Dynamic,?rootNode:js.html.Node):Void;
+    
+    public static function applyBindingsToDescendants(viewModelOrBindingContext:Dynamic,?rootNode:js.html.Node):Void;
+    
+    public static function applyBindingAccessorsToNode(node:js.html.Node, bindings:Dynamic, viewModelOrBindingContext: Dynamic):Void;
+    
+    public static function applyBindingsToNode(node:js.html.Node, bindings:Dynamic, viewModelOrBindingContext: Dynamic):Void;
+    
+    public static function contextFor(node:js.html.Node):Dynamic;
+    
+    public static function dataFor(node:js.html.Node):Dynamic;
+    
     public static function observable<T>(?value:T):ObservableExtern<T>;
 
     public static function observableArray<T>(?value:Either<Array<T>, T>):ObservableArrayExtern<T>;
 
     public static function computed<T>(evaluatorFunctionOrOptions:Either<Void -> T, DependentObservableOption<T>>):DependentObservableExtern<T>;
 
-    public static function applyBindings(viewModel:Dynamic,?rootNode:js.html.Node):Void;
-
     public static function unwrap<T>(value:Either<T, Subscribable<T>>):T;
+    
+    public static function isSubscribable(instance:Dynamic):Bool;
     
     public static function isObservable(instance:Dynamic):Bool;
     

--- a/knockout/Knockout.hx
+++ b/knockout/Knockout.hx
@@ -44,7 +44,7 @@ class Knockout {
     
     public static function applyBindingsToNode(node:js.html.Node, bindings:Dynamic, viewModelOrBindingContext: Dynamic):Void;
     
-    public static function contextFor(node:js.html.Node):Dynamic;
+    public static function contextFor(node:js.html.Node):BindingContext;
     
     public static function dataFor(node:js.html.Node):Dynamic;
     

--- a/knockout/Knockout.hx
+++ b/knockout/Knockout.hx
@@ -1,6 +1,6 @@
 package knockout;
 
-import knockout.Utils.Either;
+import haxe.extern.EitherType;
 import knockout.DependentObservable;
 import knockout.Observable;
 import knockout.ObservableArray;
@@ -48,13 +48,13 @@ extern class Knockout {
     
     public static function observable<T>(?value:T):ObservableExtern<T>;
 
-    public static function observableArray<T>(?value:Either<Array<T>, T>):ObservableArrayExtern<T>;
+    public static function observableArray<T>(?value:EitherType<T, Array<T>>):ObservableArrayExtern<T>;
 
-    public static function computed<T>(evaluatorFunctionOrOptions:Either<Void -> T, DependentObservableOption<T>>, ?evaluatorFunctionTarget:Dynamic, ?options:Dynamic):DependentObservableExtern<T>;
+    public static function computed<T>(evaluatorFunctionOrOptions:EitherType<Void -> T, DependentObservableOption<T>>, ?evaluatorFunctionTarget:Dynamic, ?options:Dynamic):DependentObservableExtern<T>;
     
-    public static function pureComputed<T>(evaluatorFunctionOrOptions:Either<Void -> T, DependentObservableOption<T>>, ?evaluatorFunctionTarget:Dynamic):DependentObservableExtern<T>;
+    public static function pureComputed<T>(evaluatorFunctionOrOptions:EitherType<Void -> T, DependentObservableOption<T>>, ?evaluatorFunctionTarget:Dynamic):DependentObservableExtern<T>;
 
-    public static function unwrap<T>(value:Either<T, Subscribable<T>>):T;
+    public static function unwrap<T>(value:EitherType<Subscribable<T>, T>):T;
     
     public static function isSubscribable(instance:Dynamic):Bool;
     

--- a/knockout/Knockout.hx
+++ b/knockout/Knockout.hx
@@ -45,12 +45,12 @@ class Knockout {
 
 
 abstract BindingHandlerMap({}){
-    @:arrayAccess public inline function arrayAccess(key:String):BindingHandler {
-        return Reflect.field(this, key);
+    @:extern @:arrayAccess public inline function arrayAccess(key:String):BindingHandler untyped {
+        return this[key];
     }
 
-    @:arrayAccess public inline function arrayWrite(key:String, value:BindingHandler):Void {
-        Reflect.setField(this, key, value);
+    @:extern @:arrayAccess public inline function arrayWrite(key:String, value:BindingHandler):Void untyped {
+        this[key] = value;
     }
 }
 

--- a/knockout/Memoization.hx
+++ b/knockout/Memoization.hx
@@ -2,8 +2,7 @@ package knockout;
 
 import js.html.Node;
 @:native("ko.memoization")
-extern
-class Memoization {
+extern class Memoization {
 
     public static function memoize(callback: Dynamic -> Void):String;
 

--- a/knockout/Observable.hx
+++ b/knockout/Observable.hx
@@ -58,8 +58,7 @@ abstract Observable<T>(ObservableExtern<T>) from ObservableExtern<T>{
 }
 
 
-extern
-class ObservableExtern<T> extends Subscribable<T> {
+extern class ObservableExtern<T> extends Subscribable<T> {
 
 inline function setter():T -> ObservableExtern<T> untyped {
     return this;
@@ -78,7 +77,6 @@ public function valueWillMutate():Void;
 }
 
 @:native("ko.observable.fn")
-extern
-class ObservableFn {
+extern class ObservableFn {
 
 }

--- a/knockout/Observable.hx
+++ b/knockout/Observable.hx
@@ -4,55 +4,55 @@ import knockout.Subscribable;
 
 abstract Observable<T>(ObservableExtern<T>) from ObservableExtern<T>{
 
-    public static var fn:Dynamic = ObservableFn; 
+    inline public static var fn:Dynamic = ObservableFn;
 
-    inline function new(observable:ObservableExtern<T>) {
+    @:extern inline function new(observable:ObservableExtern<T>) {
         this = observable;
     }
 
-    @:to inline public function toValue():T {
+    @:extern @:to inline public function toValue():T {
         return this.getter()();
     }
 
-    @:op(A << B) static inline public function setValue<T>(lhs:Observable<T>, rhs:T):Void {
+    @:extern @:op(A << B) static inline public function setValue<T>(lhs:Observable<T>, rhs:T):Void {
         lhs.set(rhs);
     }
 
-    inline public function set(newValue:T):Observable<T> {
+    @:extern inline public function set(newValue:T):Observable<T> {
         return this.setter()(newValue);
     }
 
-    inline public function get():T {
+    @:extern inline public function get():T {
         return this.getter()();
     }
 
-    inline public function peek():T {
+    @:extern inline public function peek():T {
         return this.peek();
     }
 
-    inline public function valueHasMutated():Void {
+    @:extern inline public function valueHasMutated():Void {
         this.valueHasMutated();
     }
 
-    inline public function valueWillMutate():Void {
+    @:extern inline public function valueWillMutate():Void {
         this.valueWillMutate();
     }
 
     // Subscribable methods
 
-    inline public function extend(source:Dynamic):Subscribable<T>{
+    @:extern inline public function extend(source:Dynamic):Subscribable<T>{
         return this.extend(source);
     }
 
-    inline public function dispose():Void{
+    @:extern inline public function dispose():Void{
         this.dispose();
     }
 
-    inline public function getSubscriptionsCount():Int{
+    @:extern inline public function getSubscriptionsCount():Int{
         return this.getSubscriptionsCount();
     }
 
-    inline public function subscribe(call:T -> Void, ?callbackTarget:Dynamic, ?event:String):Subscription{
+    @:extern inline public function subscribe(call:T -> Void, ?callbackTarget:Dynamic, ?event:String):Subscription{
         return this.subscribe(call, callbackTarget, event);
     }
 }

--- a/knockout/ObservableArray.hx
+++ b/knockout/ObservableArray.hx
@@ -110,8 +110,7 @@ abstract ObservableArray<T>(ObservableArrayExtern<T>) from ObservableArrayExtern
 }
 
 
-extern
-class ObservableArrayExtern<T> extends ObservableExtern<Array<T>>{
+extern class ObservableArrayExtern<T> extends ObservableExtern<Array<T>>{
 
 public function pop():Null<T>;
 
@@ -140,7 +139,6 @@ public function replace(oldItem:T, newItem:T):Void;
 }
 
 @:native("ko.observableArray.fn")
-extern
-class ObservableArrayFn {
+extern class ObservableArrayFn {
 
 }

--- a/knockout/ObservableArray.hx
+++ b/knockout/ObservableArray.hx
@@ -5,33 +5,33 @@ import knockout.Observable;
 
 abstract ObservableArray<T>(ObservableArrayExtern<T>) from ObservableArrayExtern<T>{
 
-    public static var fn:Dynamic = ObservableArrayFn;
+    inline public static var fn:Dynamic = ObservableArrayFn;
 
-    inline function new(observable:ObservableArrayExtern<T>) {
+    @:extern inline function new(observable:ObservableArrayExtern<T>) {
         this = observable;
     }
 
-    @:to inline public function toValue():Array<T> {
+    @:extern @:to inline public function toValue():Array<T> {
         return this.getter()();
     }
 
-    inline public function pop():T {
+    @:extern inline public function pop():T {
         return this.pop();
     }
 
-    inline public function push(x:T):Int {
+    @:extern inline public function push(x:T):Int {
         return this.push(x);
     }
 
-    inline public function reverse():Void {
+    @:extern inline public function reverse():Void {
         this.reverse();
     }
 
-    inline public function shift():T {
+    @:extern inline public function shift():T {
         return this.shift();
     }
 
-    inline public function sort(f:T -> T -> Int):Void {
+    @:extern inline public function sort(f:T -> T -> Int):Void {
         this.sort(f);
     }
 
@@ -40,71 +40,71 @@ abstract ObservableArray<T>(ObservableArrayExtern<T>) from ObservableArrayExtern
     @:overload(function(pos:Int, len:Int, a1:T, a2:T, a3:T):Array<T>{})
     @:overload(function(pos:Int, len:Int, a1:T, a2:T, a3:T, a4:T):Array<T>{})
     @:overload(function(pos:Int, len:Int, a1:T, a2:T, a3:T, a4:T, a5:T):Array<T>{})
-    inline public function splice(pos:Int, len:Int):Array<T> {
+    @:extern inline public function splice(pos:Int, len:Int):Array<T> {
         return this.splice(pos, len);
     }
 
-    inline public function unshift(x:T):Void {
+    @:extern inline public function unshift(x:T):Void {
         this.unshift(x);
     }
 
-    inline public function slice(pos:Int, ?end:Int):Array<T> {
+    @:extern inline public function slice(pos:Int, ?end:Int):Array<T> {
         return if (end == null) this.slice(pos) else this.slice(pos, end);
     }
 
-    inline public function remove(valueOrPredicate:Either<T -> Bool, T>):Array<T> {
+    @:extern inline public function remove(valueOrPredicate:Either<T -> Bool, T>):Array<T> {
         return this.remove(valueOrPredicate);
     }
 
-    inline public function removeAll(?arrayOfValues:Array<T>):Array<T> {
+    @:extern inline public function removeAll(?arrayOfValues:Array<T>):Array<T> {
         return if (arrayOfValues == null) this.removeAll() else this.removeAll(arrayOfValues);
     }
 
-    inline public function indexOf(item:T):Int {
+    @:extern inline public function indexOf(item:T):Int {
         return this.indexOf(item);
     }
 
-    inline public function replace(oldItem:T, newItem:T):Void {
+    @:extern inline public function replace(oldItem:T, newItem:T):Void {
         this.replace(oldItem, newItem);
     }
 
 // Observable methods
 
-    inline public function set(newValue:Array<T>):Observable<Array<T>> {
+    @:extern inline public function set(newValue:Array<T>):Observable<Array<T>> {
         return this.setter()(newValue);
     }
 
-    inline public function get():Array<T> {
+    @:extern inline public function get():Array<T> {
         return this.getter()();
     }
 
-    inline public function peek():Array<T> {
+    @:extern inline public function peek():Array<T> {
         return this.peek();
     }
 
-    inline public function valueHasMutated():Void {
+    @:extern inline public function valueHasMutated():Void {
         this.valueHasMutated();
     }
 
-    inline public function valueWillMutate():Void {
+    @:extern inline public function valueWillMutate():Void {
         this.valueWillMutate();
     }
 
 // Subscribable methods
 
-    inline public function extend(source:Dynamic):Subscribable<Array<T>> {
+    @:extern inline public function extend(source:Dynamic):Subscribable<Array<T>> {
         return this.extend(source);
     }
 
-    inline public function dispose():Void {
+    @:extern inline public function dispose():Void {
         this.dispose();
     }
 
-    inline public function getSubscriptionsCount():Int {
+    @:extern inline public function getSubscriptionsCount():Int {
         return this.getSubscriptionsCount();
     }
 
-    inline public function subscribe(call:Array<T> -> Void, ?callbackTarget:Dynamic, ?event:String):Subscription {
+    @:extern inline public function subscribe(call:Array<T> -> Void, ?callbackTarget:Dynamic, ?event:String):Subscription {
         return this.subscribe(call, callbackTarget, event);
     }
 }

--- a/knockout/ObservableArray.hx
+++ b/knockout/ObservableArray.hx
@@ -1,6 +1,5 @@
 package knockout;
-import Array;
-import knockout.Utils.Either;
+import haxe.extern.EitherType;
 import knockout.Observable;
 
 abstract ObservableArray<T>(ObservableArrayExtern<T>) from ObservableArrayExtern<T>{
@@ -9,10 +8,6 @@ abstract ObservableArray<T>(ObservableArrayExtern<T>) from ObservableArrayExtern
 
     @:extern inline function new(observable:ObservableArrayExtern<T>) {
         this = observable;
-    }
-
-    @:extern @:to inline public function toValue():Array<T> {
-        return this.getter()();
     }
 
     @:extern inline public function pop():T {
@@ -52,7 +47,7 @@ abstract ObservableArray<T>(ObservableArrayExtern<T>) from ObservableArrayExtern
         return if (end == null) this.slice(pos) else this.slice(pos, end);
     }
 
-    @:extern inline public function remove(valueOrPredicate:Either<T -> Bool, T>):Array<T> {
+    @:extern inline public function remove(valueOrPredicate:EitherType<T -> Bool, T>):Array<T> {
         return this.remove(valueOrPredicate);
     }
 
@@ -128,7 +123,7 @@ public function unshift( x:T ):Void;
 
 public function slice( pos:Int, ?end:Int ):Array<T>;
 
-public function remove(valueOrPredicate:Either<T -> Bool, T>):Array<T>;
+public function remove(valueOrPredicate:EitherType<T -> Bool, T>):Array<T>;
 
 public function removeAll(?arrayOfValues:Array<T>):Array<T>;
 

--- a/knockout/SelectExtensions.hx
+++ b/knockout/SelectExtensions.hx
@@ -1,0 +1,12 @@
+package knockout;
+
+import js.html.Element;
+@:native("ko.selectExtensions")
+extern
+class SelectExtensions {
+
+    public function readValue(element:Element):Bool;
+
+    public function writeValue(element:Element, value:String):Bool;
+
+}

--- a/knockout/SelectExtensions.hx
+++ b/knockout/SelectExtensions.hx
@@ -2,8 +2,7 @@ package knockout;
 
 import js.html.Element;
 @:native("ko.selectExtensions")
-extern
-class SelectExtensions {
+extern class SelectExtensions {
 
     public function readValue(element:Element):Bool;
 

--- a/knockout/Subscribable.hx
+++ b/knockout/Subscribable.hx
@@ -1,7 +1,6 @@
 package knockout;
 @:native("ko.subscribable")
-extern
-class Subscribable<T> {
+extern class Subscribable<T> {
 
     public static var fn(default,null):Dynamic;
 

--- a/knockout/Subscription.hx
+++ b/knockout/Subscription.hx
@@ -1,6 +1,5 @@
 package knockout;
-extern
-class Subscription {
+extern class Subscription {
 
     public function dispose():Void;
 }

--- a/knockout/TemplateEngine.hx
+++ b/knockout/TemplateEngine.hx
@@ -8,7 +8,7 @@ extern
 class TemplateEngine {
     public var allowTemplateRewriting:Bool;
     
-    public function renderTemplateSource(templateSource:Dynamic, bindingContext:BindingContext, option:Dynamic):Dynamic;
+    public function renderTemplateSource(templateSource:TemplateSource, bindingContext:BindingContext, option:Dynamic):Dynamic;
     
     public function createJavaScriptEvaluatorBlock(script:String):String;
     

--- a/knockout/TemplateEngine.hx
+++ b/knockout/TemplateEngine.hx
@@ -4,8 +4,7 @@ import js.html.Document;
 import knockout.BindingContext;
 
 @:native("ko.templateEngine")
-extern
-class TemplateEngine {
+extern class TemplateEngine {
     public var allowTemplateRewriting:Bool;
     
     public function renderTemplateSource(templateSource:TemplateSource, bindingContext:BindingContext, option:Dynamic):Dynamic;

--- a/knockout/TemplateSource.hx
+++ b/knockout/TemplateSource.hx
@@ -1,0 +1,28 @@
+package knockout;
+
+import js.html.Node;
+interface TemplateSource {
+
+    public function text(?valueToWrite:Dynamic):Dynamic;
+
+    public function data(key:String, ?valueToWrite:Dynamic):Dynamic;
+    
+    public function nodes(?valueToWrite:Dynamic):Dynamic;
+
+}
+
+@:native("ko.templateSources.domElement")
+extern
+class DomElement implements TemplateSource{
+
+    public function new(element:Node);
+
+}
+
+@:native("ko.templateSources.anonymousTemplate")
+extern
+class AnonymousTemplate extends DomElement{
+
+    public function new(element:Node);
+
+}

--- a/knockout/TemplateSource.hx
+++ b/knockout/TemplateSource.hx
@@ -1,21 +1,27 @@
 package knockout;
 
 import js.html.Node;
-interface TemplateSource {
+typedef TemplateSource = {
 
-    public function text(?valueToWrite:Dynamic):Dynamic;
+    function text(?valueToWrite:Dynamic):Dynamic;
 
-    public function data(key:String, ?valueToWrite:Dynamic):Dynamic;
+    function data(key:String, ?valueToWrite:Dynamic):Dynamic;
     
-    public function nodes(?valueToWrite:Dynamic):Dynamic;
+    function nodes(?valueToWrite:Dynamic):Dynamic;
 
 }
 
 @:native("ko.templateSources.domElement")
 extern
-class DomElement implements TemplateSource{
+class DomElement{
 
     public function new(element:Node);
+
+    public function text(?valueToWrite:Dynamic):Dynamic;
+
+    public function data(key:String, ?valueToWrite:Dynamic):Dynamic;
+
+    public function nodes(?valueToWrite:Dynamic):Dynamic;
 
 }
 

--- a/knockout/Utils.hx
+++ b/knockout/Utils.hx
@@ -1,7 +1,7 @@
 package knockout;
+import haxe.extern.EitherType;
 import js.html.Element;
 import js.html.Node;
-import knockout.Utils.Either;
 import knockout.Subscribable;
 @:native("ko.utils")
 extern class Utils {
@@ -22,17 +22,17 @@ extern class Utils {
     
     public static function arrayMap<T1, T2>(array:Array<T1>, mapping:T1 -> T2):Array<T2>;
     
-    public static function arrayPushAll<T>(array:Either<Array<T>, ObservableArray<T>>, valuesToPush:Array<T>):Array<T>;
+    public static function arrayPushAll<T>(array:EitherType<Array<T>, ObservableArray<T>>, valuesToPush:Array<T>):Array<T>;
     
-    public static function arrayRemoveItem<T>(array:Either<Array<T>, ObservableArray<T>>, itemToRemove:T):Void;
+    public static function arrayRemoveItem<T>(array:EitherType<Array<T>, ObservableArray<T>>, itemToRemove:T):Void;
     
     public static function extend(target:Dynamic, source:Dynamic):Void;
     
-    public static function getFormFields(form:Element, fieldName:Either<String, EReg>):Array<Node>;
+    public static function getFormFields(form:Element, fieldName:EitherType<String, EReg>):Array<Node>;
     
-    public static function peekObservable<T>(value:Either<T, Subscribable<T>>):T;
+    public static function peekObservable<T>(value:EitherType<T, Subscribable<T>>):T;
     
-    public static function postJson(urlOrForm:Either<String, Element>, data:Either<Dynamic, Subscribable<Dynamic>>, options:Dynamic):Void;
+    public static function postJson(urlOrForm:EitherType<String, Element>, data:EitherType<Dynamic, Subscribable<Dynamic>>, options:Dynamic):Void;
     
     public static function parseJson(jsonString:String):Dynamic;
     
@@ -40,13 +40,13 @@ extern class Utils {
     
     public static function stringifyJson(data:Dynamic):String;
     
-    public static function range(min:Either<Int, Subscribable<Int>>, max:Either<Int, Subscribable<Int>>):Array<Int>;
+    public static function range(min:EitherType<Int, Subscribable<Int>>, max:EitherType<Int, Subscribable<Int>>):Array<Int>;
     
     public static function toggleDomNodeCssClass(node:Element, className:String, shouldHaveClass:Bool):Void;
     
     public static function triggerEvent(element:Node, eventType:String):Void;
     
-    public static function unwrapObservable<T>(value:Either<T, Subscribable<T>>):T;
+    public static function unwrapObservable<T>(value:EitherType<T, Subscribable<T>>):T;
     
     public static function objectForEach(obj:Dynamic, action:String -> Dynamic -> Void):Void;
     
@@ -61,5 +61,3 @@ extern class Utils {
     public static function setDomNodeChildrenFromArrayMapping(domNode:Node, array:Array<Dynamic>, mapping:Dynamic, options:Dynamic, callbackAfterAddingNodes: Dynamic -> Array<Dynamic> -> Int -> Void):Void;
 
 }
-
-abstract Either<T1, T2>(Dynamic) from T1 from T2 to T1 to T2 {}

--- a/knockout/Utils.hx
+++ b/knockout/Utils.hx
@@ -4,8 +4,7 @@ import js.html.Node;
 import knockout.Utils.Either;
 import knockout.Subscribable;
 @:native("ko.utils")
-extern
-class Utils {
+extern class Utils {
     
     public static var fieldsIncludedWithJsonPost:Array<Dynamic>;
     

--- a/knockout/Utils.hx
+++ b/knockout/Utils.hx
@@ -9,6 +9,8 @@ class Utils {
     
     public static var fieldsIncludedWithJsonPost:Array<Dynamic>;
     
+    public static var domData:DomData;
+    
     public static function arrayForEach<T>(array:Array<T>, action:T -> Void):Void;
     
     public static function arrayFirst<T>(array:Array<T>, predicate:T -> Bool, ?predicateOwner:Dynamic):Null<T>;
@@ -54,6 +56,10 @@ class Utils {
     public static function parseHtmlFragment(template:Dynamic):Dynamic;
     
     public static function setHtml(node:Node, html:Dynamic):Void;
+    
+    public static function compareArrays(oldArray:Array<Dynamic>, newArray:Array<Dynamic>, options:Dynamic):Array<Dynamic>;
+    
+    public static function setDomNodeChildrenFromArrayMapping(domNode:Node, array:Array<Dynamic>, mapping:Dynamic, options:Dynamic, callbackAfterAddingNodes: Dynamic -> Array<Dynamic> -> Int -> Void):Void;
 
 }
 

--- a/knockout/VirtualElements.hx
+++ b/knockout/VirtualElements.hx
@@ -2,8 +2,7 @@ package knockout;
 
 import js.html.Node;
 @:native("ko.virtualElements")
-extern
-class VirtualElements {
+extern class VirtualElements {
 
     public var allowedBindings:Dynamic<Bool>;
 

--- a/knockout/VirtualElements.hx
+++ b/knockout/VirtualElements.hx
@@ -1,0 +1,18 @@
+package knockout;
+
+import js.html.Node;
+@:native("ko.virtualElements")
+extern
+class VirtualElements {
+
+    public var allowedBindings:Dynamic<Bool>;
+
+    public function emptyNode(node:Node):Void;
+
+    public function insertAfter(containerNode:Node, nodeToInsert:Node, insertAfterNode:Node):Void;
+
+    public function prepend(containerNode:Node, nodeToPrepend:Node):Void;
+
+    public function setDomNodeChildren(node:Node, childNodes:Array<Node>):Void;
+
+}

--- a/test/Test.hx
+++ b/test/Test.hx
@@ -55,7 +55,7 @@ class Test {
 
         var array2 = new Array<Float>();
         Utils.arrayPushAll(observableArray, array2);
-        
+
         observableArray = Knockout.observableArray(1.0);
 
     }
@@ -65,6 +65,13 @@ class Test {
 
         var computed:DependentObservable<String> = Knockout.computed(function() {
             return observable.get();
+        });
+    }
+
+    public static function components() {
+        Knockout.components.register("widget", {
+        viewModel: function(params:Dynamic) {},
+        template:"<div></div>"
         });
     }
 

--- a/test/Test.hx
+++ b/test/Test.hx
@@ -51,7 +51,7 @@ class Test {
         observableArray.push(10);
         var pos = observableArray.indexOf(10);
 
-        var inner:Array<Float> = observableArray;
+        var inner:Array<Float> = observableArray.get();
 
         var array2 = new Array<Float>();
         Utils.arrayPushAll(observableArray, array2);


### PR DESCRIPTION
With a haxe4 compiler, `haxe compile.hxml` fails with the following outputs:
```
knockout/BindingContext.hx:6: characters 24-35 : parents: Custom property accessor is no longer supported, please use `get`
knockout/BindingContext.hx:7: characters 21-29 : root: Custom property accessor is no longer supported, please use `get`
knockout/BindingContext.hx:8: characters 21-29 : data: Custom property accessor is no longer supported, please use `get`
knockout/BindingContext.hx:9: characters 22-31 : index: Custom property accessor is no longer supported, please use `get`
knockout/BindingContext.hx:10: characters 30-47 : parentContext: Custom property accessor is no longer supported, please use `get`
knockout/BindingContext.hx:11: characters 24-35 : context: Custom property accessor is no longer supported, please use `get`
knockout/BindingContext.hx:12: characters 24-35 : element: Custom property accessor is no longer supported, please use `get`
```

This PR fixes the problem.